### PR TITLE
fix: Small bug in potter Kata

### DIFF
--- a/src/potter/potter.js
+++ b/src/potter/potter.js
@@ -52,5 +52,5 @@ function calculatePriceBasedOnTheNumberOfBooks(books) {
 }
 
 function removeDiscountedBooks(books) {
-  return books.map(x => x - 1);
+  return books.map(x => x - 1).filter(x => x > 0);
 }

--- a/test/potter/potter.spec.js
+++ b/test/potter/potter.spec.js
@@ -73,6 +73,19 @@ describe("Potter spec", () => {
 
     expect(calculatePrice(cart)).to.equal(23.2);
   });
+  
+  it("five different books plus one cost 38,0 EUR", () => {
+    const cart = [
+      HarryPotterBook.BOOK_1,
+      HarryPotterBook.BOOK_2,
+      HarryPotterBook.BOOK_2,
+      HarryPotterBook.BOOK_3,
+      HarryPotterBook.BOOK_4,
+      HarryPotterBook.BOOK_5
+    ];
+
+    expect(calculatePrice(cart)).to.equal(38.0);
+  });
 
   function arbitraryBook() {
     return jsc.suchthat(


### PR DESCRIPTION
Hi! 

After summoning this repo, I've found a small bug in the potter kata. 
The problem was that `groupBooks` was returning a map with a structure like:
```
{
  "1": 1,
  "2": 2,
  "3": 1,
  ... 
}
```
and after decreasing the counter inside `removeDiscountedBooks`, we could have 
```
{
  "1": 0,
  "2": 1,
  "3": 0,
  ... 
}
```
so, when obtaining `books[0]`, we could get a `0` instead of a `1`, which calculates a wrong price. Instead of getting `8 * 1 = 8`, we would get  `8 * 0 = 0`.

One possible solution would be to remove the entries from the Map where the value is `0` in `removeDiscountedBooks`.
I wrote it in this PR. I Hope you find it useful :smiley: 

I've added a test that makes the current master branch fail. If you remove the `.filter()` in this PR, you will see that the test expects 38 and gets 30. 